### PR TITLE
Allow operation in a subdirectory of a repository

### DIFF
--- a/git-recall
+++ b/git-recall
@@ -25,7 +25,7 @@ COMMITS=""
 VERSION="1.1.1"
 
 # Are we in a git repo?
-if [[ ! -d ".git" ]]; then
+if [[ ! -d ".git" ]] && ! git rev-parse --git-dir &>/dev/null; then
   echo "abort: not a git repository." 1>&2
   exit 1
 fi


### PR DESCRIPTION
The script exited if you ran it in a sub-directory of a repository, but git allows for the execution of commands in sub-directories. This patch adds a check to see if any parent directory contains a repository and allows to proceed if that is the case. 
For comparison, git's [bash_completion](https://github.com/git/git/blob/master/contrib/completion/git-completion.bash#L47) is handled similarly.
fixes #9