### PR TITLE
added option to only show local commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ check what you or other contributors in your team did. It doesn't aim to be a re
 ```sh
 $ git recall   [-a <author name>] 
 	           [-d <days-ago>]
+               [-l]
                [-f]
                [-h]
 ```
@@ -24,6 +25,7 @@ $ git recall   [-a <author name>]
 
 - `-a`      - Restrict search for a specific user (use -a "all" for all users)
 - `-d`      - Display commits for the last n days
+- `-l`      - show commits that have not been pushed to the remote branch.
 - `-f`      - Fetch the latest changes
 - `-h`      - Show help screen
 
@@ -53,6 +55,9 @@ $ git recall -d 5 -a "Doge"
 
 $ git recall -d 5 -a "all"
 # The command will show commits of all contributors from 5 days ago.
+
+$ git recall -l
+# The command will show commits that are present on the local branch, but have not yet been pushed to the remote. 
 ```
 
 

--- a/git-recall
+++ b/git-recall
@@ -10,6 +10,7 @@ usage() {
     -a, --author            Author name.
     -f, --fetch             fetch commits.
     -h, --help              This message.
+    -l, --local             Only show commits that have not yet been pushed to the remote branch.
     --                      End of options.
 EOF
 }
@@ -23,6 +24,8 @@ GIT_FORMAT=""
 GIT_LOG=""
 COMMITS=""
 VERSION="1.1.1"
+TEMPLATE="default"
+CURRENT_BRANCH=""
 
 # Are we in a git repo?
 if [[ ! -d ".git" ]]; then
@@ -47,6 +50,9 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
       ;;
     -f | --fetch )
       FETCH=true
+      ;;
+    -l | --local )
+      TEMPLATE="local"
       ;;
     -h | --help )
       usage
@@ -113,10 +119,30 @@ fi
 # Log template.
 GIT_FORMAT="%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset"
 
-# Log command.
-GIT_LOG="git log --pretty=format:'${GIT_FORMAT}'  
-           --author \"$AUTHOR\"
-           --since \"$SINCE\" --abbrev-commit"
+# Get currently tracked branch
+function get_current_branch() {
+  if ! CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD); then
+    echo "abort" 1>&2
+    exit 1
+  fi
+}
+
+# Log command templates
+function set_log_command() {
+  if [ "$TEMPLATE" == "local" ]; then
+    get_current_branch
+    GIT_LOG="git log --pretty=format:'${GIT_FORMAT}'
+                 --abbrev-commit
+                 origin/${CURRENT_BRANCH}..HEAD
+                 "
+  else
+    GIT_LOG="git log --pretty=format:'${GIT_FORMAT}'
+                  --author \"$AUTHOR\"
+                  --since \"$SINCE\" --abbrev-commit"
+  fi
+}
+
+set_log_command
 
 # Change temporary the IFS to store GIT_LOG's output into an array.
 IFS=$'\n'


### PR DESCRIPTION
Added an option -l/--local to show only commits that are ahead of origin/{branch}.
For this I introduced the function `set_log_command()` to select a different command template as it makes little sense to filter author and date in combination with -local, at least by default. The command is expected to show ALL commits ahead of the remote branch.

One thing I don't like is the error handling for the git log command.
`COMMITS=($(eval ${GIT_LOG} 2>/dev/null))`
when using the -local option and the branch origin/{branch}  does not exist yet (as is the case if you
just created the new branch and didn't push anything yet) the error does not get caught and instead
the "did nothing during this period" message is shown.  So error handling should be added, but
that goes beyond this PR.

