### PR TITLE
Fixes #13. Different param name on OSX for Sed program.

### DIFF
--- a/git-recall
+++ b/git-recall
@@ -149,7 +149,12 @@ echo "\t quit" | lesskey -o $HOME/.lsh_less_keys_tmp -- - &> /dev/null
 
 ## Get commit's diff.
 function get_diff() {
-    ELT="$(echo "${COMMITS[$CP-1]}" | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g")" # remove colors escape codes
+    case "$OSTYPE" in
+      darwin*) SED_BIN="sed -E" ;;
+      *)       SED_BIN="sed -r" ;;
+    esac
+
+    ELT="$(echo "${COMMITS[$CP-1]}" | $SED_BIN "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g")" # remove colors escape codes
     DIFF_TIP=${ELT:0:7}
     DIFF_CMD="git show $DIFF_TIP --color=always"
     DIFF=$(eval ${DIFF_CMD} 2>/dev/null)


### PR DESCRIPTION
Sed on Mac OSX is using "-E" param instead of "-r" param on Linux for
extended regexp evaluation. Adding switch/case statement allows to set
valid parameter depending on the operating system type.