### PR TITLE
Allow to override Makefile prefix variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-PREFIX = /usr/local
-BINPREFIX = "$(PREFIX)/bin"
+PREFIX ?= /usr/local
+BINPREFIX ?= "$(PREFIX)/bin"
 
 LIB=git-recall
 


### PR DESCRIPTION
#### Why you made this change:
On a shared server not all users are granted with write access to the `/usr/local` dir. I did it to allow installing `git-recall` in chosen path i.e. `/home/kiela` dir.

#### How the change addresses the need:
It allows overriding `PREFIX` and `BINPREFIX` variables when needed. Otherwise set them to default values.

#### Testing procedure:

1. Install `git-recall` to your home dir:

```
PREFIX=$HOME make install
```

2. Now you should have `git-recall` in your `$HOME/bin` dir.

3. Uninstall `git-recall` from your home dir:

```
PREFIX=$HOME make uninstall
```
