### PR TITLE
Handle Ctrl-C interrupt

### DIFF
--- a/git-recall
+++ b/git-recall
@@ -191,15 +191,23 @@ function get_diff() {
     DIFF_LINES_NUMBER=$(( DIFF_LINES_NUMBER + off ))
 }
 
+cleanup_diff()
+{
+  clear_screen
+  cleanup_and_exit
+}
+
 # This function will print the diff according the commit's tip. If the diff is too long, the result will be displayed using 'less'. 
 function print_diff() {
     get_diff
     if [[ $(( TN + DIFF_LINES_NUMBER + OFFSET )) -ge $(( `tput lines` - 1 )) ]]; then
+  trap cleanup_diff INT
 	if [[ $LESSKEY = true ]]; then
-	    echo "$DIFF" | less -r -k $HOME/.lsh_less_keys_tmp
+    (echo "$DIFF" | less -r -k $HOME/.lsh_less_keys_tmp)
 	else 
-	    echo "$DIFF" | less -r
+    (echo "$DIFF" | less -r)
 	fi
+  trap cleanup_and_exit INT
 	clear_screen
     else 
 	stop=false

--- a/git-recall
+++ b/git-recall
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-
-
 # usage info
 usage() {
   cat <<EOF
@@ -248,6 +246,20 @@ function calculate_offset {
     done
 }
 
+# Reset changes made by this script before exiting
+cleanup_and_exit()
+{
+    # remove temporary less keybindings
+    [[ $LESSKEY = true ]] && rm $HOME/.lsh_less_keys_tmp
+
+    tput cnorm      # unhide cursor
+    echo "$NORMAL"  # normal colors
+    exit
+}
+
+# Catch a control-C interrupt and perform cleanup operations before exiting
+trap cleanup_and_exit INT
+
 { # capture stdout to stderr
 
 tput civis   # hide cursor.
@@ -325,11 +337,7 @@ do
     esac
 done
 
-# remove temporary less keybindings
-[[ $LESSKEY = true ]] && rm $HOME/.lsh_less_keys_tmp 
-
-tput cnorm      # unhide cursor
-echo "$NORMAL"  # normal colors
+cleanup_and_exit
 
 } >&2 # END capture
 

--- a/git-recall
+++ b/git-recall
@@ -263,8 +263,12 @@ cleanup_and_exit()
 
     tput cnorm      # unhide cursor
     echo "$NORMAL"  # normal colors
+    stty "$orig_stty" > /dev/null 2>&1
     exit
 }
+
+# Store original terminal settings
+orig_stty=$(stty -g)
 
 # Catch a control-C interrupt and perform cleanup operations before exiting
 trap cleanup_and_exit INT

--- a/git-recall
+++ b/git-recall
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+
 # usage info
 usage() {
   cat <<EOF
@@ -205,7 +206,7 @@ function print_diff() {
 	if [[ $LESSKEY = true ]]; then
 	    echo "$DIFF" | less -r -k /tmp/lsh_less_keys_tmp
 	else 
-    echo "$DIFF" | less -r
+	    echo "$DIFF" | less -r
 	fi
   trap cleanup_and_exit INT
 	clear_screen


### PR DESCRIPTION
Out of habit I'd often exit this script with Ctrl-C instead of by hitting q, but this would cause problems with the cursor never being unhidden and hitting Ctrl-C in diff view would cause the terminal to fill with junk. Fixed by trapping Ctrl-C and resetting cursor and colours before exiting.