### PR TITLE
Add option to specify branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ check what you or other contributors in your team did. It doesn't aim to be a re
 ```sh
 $ git recall   [-a <author name>]
                [-d <days-ago>]
+               [-b <branch name>]
                [-f]
                [-h]
                [-v]
@@ -25,6 +26,7 @@ $ git recall   [-a <author name>]
 
 - `-a`      - Restrict search for a specific user (use -a "all" for all users)
 - `-d`      - Display commits for the last n days
+- `-b`      - Specify branch to display commits from
 - `-f`      - Fetch the latest changes
 - `-h`      - Show help screen
 - `-v`      - Show version

--- a/git-recall
+++ b/git-recall
@@ -8,6 +8,7 @@ usage() {
   Options:
     -d, --date              Show logs for last n days.
     -a, --author            Author name.
+    -b, --branch            Specify branch to display commits from.
     -f, --fetch             fetch commits.
     -h, --help              This message.
     -v, --version           Show version.
@@ -27,6 +28,7 @@ COMMITS_UNCOL=()       # commits without colors
 SED_CMD=""             # Sed command to use according OS.
 LESSKEY=false
 VERSION="1.2.2"
+BRANCH=""
 
 # Set key bindings.
 au="`echo -e '\e[A'`" # arrow up
@@ -87,6 +89,10 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
 	    usage
 	    exit
 	    ;;
+    -b | --branch )
+        BRANCH="$2"
+        shift
+        ;;
 	* )
 	    echo "abort: unknown argument" 1>&2
 	    exit 1
@@ -128,7 +134,7 @@ GIT_FORMAT="%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%a
 # Log command.
 GIT_LOG="git log --pretty=format:'${GIT_FORMAT}'  
            --author \"$AUTHOR\"
-           --since \"$SINCE\" --abbrev-commit --no-merges"
+           --since \"$SINCE\" --abbrev-commit --no-merges $BRANCH"
 
 # Change temporary the IFS to store GIT_LOG's output into an array.
 IFS=$'\n'


### PR DESCRIPTION
Specify branch name with -b (or --branch) to recall commits made on a different branch to the one that is checked out. So for example if I'm working on master and want to quickly browse commits I've made in a different release branch I can do so without checking out the release branch, avoiding a lengthy re-build when I go back to master.

Works very simply, just pass the branch name through to the git log command as the only positional parameter. Passing empty string gives usual default behaviour of displaying commits from the current checked-out branch.