### PR TITLE
Allow limiting history to path/s or file/s

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ check what you or other contributors in your team did. It doesn't aim to be a re
 $ git recall   [-a <author name>]
                [-d <days-ago>]
                [-b <branch name>]
+               [-p <paths>]
                [-f]
                [-h]
                [-v]
@@ -27,6 +28,7 @@ $ git recall   [-a <author name>]
 - `-a`      - Restrict search for a specific user (use -a "all" for all users)
 - `-d`      - Display commits for the last n days
 - `-b`      - Specify branch to display commits from
+- `-p`      - Specify path/s or file/s to display commits from
 - `-f`      - Fetch the latest changes
 - `-h`      - Show help screen
 - `-v`      - Show version

--- a/git-recall
+++ b/git-recall
@@ -9,6 +9,7 @@ usage() {
     -d, --date              Show logs for last n days.
     -a, --author            Author name.
     -b, --branch            Specify branch to display commits from.
+    -p  --path              Specify path or filename to display commits from.
     -f, --fetch             fetch commits.
     -h, --help              This message.
     -v, --version           Show version.
@@ -29,6 +30,7 @@ SED_CMD=""             # Sed command to use according OS.
 LESSKEY=false
 VERSION="1.2.3"
 BRANCH=""
+SEARCH_PATH=""
 
 # Set key bindings.
 au="`echo -e '\e[A'`" # arrow up
@@ -93,6 +95,10 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
             BRANCH="$2"
             shift
             ;;
+        -p | --path )
+            SEARCH_PATH="$2"
+            shift
+            ;;
 	* )
 	    echo "abort: unknown argument" 1>&2
 	    exit 1
@@ -134,7 +140,7 @@ GIT_FORMAT="%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%a
 # Log command.
 GIT_LOG="git log --pretty=format:'${GIT_FORMAT}'  
            --author \"$AUTHOR\"
-           --since \"$SINCE\" --abbrev-commit --no-merges $BRANCH"
+           --since \"$SINCE\" --abbrev-commit --no-merges $BRANCH $SEARCH_PATH"
 
 # Change temporary the IFS to store GIT_LOG's output into an array.
 IFS=$'\n'
@@ -191,7 +197,7 @@ fi
 function get_diff() {
     ELT="$(echo "${COMMITS_UNCOL[$CP-1]}")"
     DIFF_TIP=${ELT:0:7}
-    DIFF_CMD="git show $DIFF_TIP --color=always"
+    DIFF_CMD="git show $DIFF_TIP --color=always $SEARCH_PATH"
     DIFF=$(eval ${DIFF_CMD} 2>/dev/null)
     tmp_diff="$(echo "$DIFF" | $SED_CMD)"
     off=$(echo "$tmp_diff" | grep -c ".\{$CN\}") # Number of lines in the diff that are longer than terminal width.


### PR DESCRIPTION
As I mentioned in #18 the option to limit to a certain file is something I'd love. Almost a year later here is a pull request for you. 😆 

Changes allow you to specify a path or file name with -p (or --paths) to recall commits only made on that path or file name. 

Implementation is pretty simple, just adding whatever is passed in to the end of the `git log` & `git show` command. 

I'm unsure if having it on `git show` should be a flag or not, for my use case when viewing the diff I again only want to see the path or files specified, I'm unsure if anyone else would think differently, and if so what the default behavior should be. Any input on that would be great and I can make any changes needed. 
  